### PR TITLE
Port mod to NeoForge 1.21.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,14 +21,17 @@ version.1_21_4.forge_loader = 54.1.0
 # NeoForge Loader
 version.1_21_5.neoforge_loader = 21.5.0-beta
 version.1_21_4.neoforge_loader = 21.4.124
+version.1_21_1.neoforge_loader = 21.1.1
 
 # Parchment Minecraft versions
 version.1_21_5.parchment_minecraft_version = 1.21.4
 version.1_21_4.parchment_minecraft_version = 1.21.4
+version.1_21_1.parchment_minecraft_version = 1.21.1
 
 # Parchment mapping versions
 version.1_21_5.parchment_mappings_version = 2025.03.23
 version.1_21_4.parchment_mappings_version = 2025.03.23
+version.1_21_1.parchment_mappings_version = 2025.03.23
 
 
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,11 +19,11 @@ stonecutter {
     centralScript = "build.gradle.kts"
     kotlinController = true
     create(rootProject) {
-        versions("1.21.5")
-        vcsVersion = "1.21.5"
+        versions("1.21.1")
+        vcsVersion = "1.21.1"
         branch("fabric")
-        //branch("forge") { versions("1.21.5") }+
-        branch("neoforge") { versions("1.21.5") }
+        //branch("forge") { versions("1.21.1") }+
+        branch("neoforge") { versions("1.21.1") }
     }
 }
 

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 	id("architectury-plugin") version "3.4-SNAPSHOT" apply false
 	id("com.github.johnrengelman.shadow") version "8.1.1" apply false
 }
-stonecutter active "1.21.5" /* [SC] DO NOT EDIT */
+stonecutter active "1.21.1" /* [SC] DO NOT EDIT */
 
 // Builds every version into `build/libs/{mod.version}/{loader}`
 stonecutter registerChiseled tasks.register("chiseledBuild", stonecutter.chiseled) {


### PR DESCRIPTION
## Summary
- switch active version to 1.21.1 in stonecutter config
- update settings to build 1.21.1 branch
- add NeoForge 1.21.1 properties

## Testing
- `./gradlew tasks --no-daemon` *(fails: Cannot remap lambda)*

------
https://chatgpt.com/codex/tasks/task_e_6843450e87ac832bbd91c34dcf8a0a06